### PR TITLE
#24 fix auth services

### DIFF
--- a/src/main/java/com/book/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/book/backend/domain/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.book.backend.domain.auth.dto.LoginDto;
 import com.book.backend.domain.auth.dto.SignupDto;
 import com.book.backend.domain.auth.service.AuthService;
 import com.book.backend.domain.user.dto.UserDto;
+import com.book.backend.global.log.RequestLogger;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,21 +25,24 @@ public class AuthController {
 
     @PostMapping("/signup")
     public ResponseEntity<UserDto> signup(@Valid @RequestBody SignupDto signupDto) {
-        log.info("signup 호출");
+        RequestLogger.body(signupDto);
+
         UserDto userDto = authService.signup(signupDto);
         return ResponseEntity.ok(userDto);
     }
 
     @PostMapping("/login")
     public ResponseEntity<UserDto> login(@Valid @RequestBody LoginDto loginDto) {
-        log.info("login 호출");
+        RequestLogger.body(loginDto);
+
         UserDto userDto = authService.login(loginDto);
         return ResponseEntity.ok(userDto);
     }
 
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletRequest request) {
-        log.info("logout 호출");
+        RequestLogger.param(new String[] {"Session ID"}, request.getSession().getId());
+
         request.getSession().invalidate();
         SecurityContextHolder.clearContext();
         return new ResponseEntity<>(HttpStatus.OK);
@@ -46,7 +50,8 @@ public class AuthController {
 
     @DeleteMapping("/delete")
     public ResponseEntity<Void> deleteAccount(HttpServletRequest request) {
-        log.info("deleteAccount 호출");
+        RequestLogger.param(new String[] {"Session ID"}, request.getSession().getId());
+
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String loginId = authentication.getName();
 

--- a/src/main/java/com/book/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/book/backend/domain/auth/controller/AuthController.java
@@ -32,10 +32,10 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<UserDto> login(@Valid @RequestBody LoginDto loginDto) {
+    public ResponseEntity<UserDto> login(HttpServletRequest request, @Valid @RequestBody LoginDto loginDto) {
         RequestLogger.body(loginDto);
 
-        UserDto userDto = authService.login(loginDto);
+        UserDto userDto = authService.login(request, loginDto);
         return ResponseEntity.ok(userDto);
     }
 

--- a/src/main/java/com/book/backend/domain/auth/controller/SessionInfoController.java
+++ b/src/main/java/com/book/backend/domain/auth/controller/SessionInfoController.java
@@ -1,0 +1,64 @@
+package com.book.backend.domain.auth.controller;
+
+import com.book.backend.global.log.RequestLogger;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Date;
+
+@RestController
+@RequestMapping("/api/session-info")
+@RequiredArgsConstructor
+@Slf4j
+public class SessionInfoController {
+
+    @GetMapping
+    public String sessionInfo(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session == null) {
+            return "세션이 없습니다.";
+        }
+
+        // 세션에 저장된 모든 속성의 이름을 가져와 로그에 출력
+        session.getAttributeNames().asIterator().forEachRemaining(name ->
+                log.info("session name={}, value={}", name, session.getAttribute(name))
+        );
+
+        // Spring Security Context에서 인증 정보 불러와서 출력
+        SecurityContext context = SecurityContextHolder.getContext();
+        Authentication authentication = context.getAuthentication();
+
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object principal = authentication.getPrincipal();
+            if (principal instanceof User user) {
+                log.info("username={}", user.getUsername());
+                log.info("authorities={}", user.getAuthorities());
+            } else {
+                log.info("principal={}", principal);
+            }
+        } else {
+            log.info("사용자가 인증되지 않았습니다.");
+        }
+
+        // 세션 정보를 로그에 출력
+        RequestLogger.param(new String[] {"sessionId", "maxInactiveInterval", "creationTime", "lastAccessedTime", "isNew"},
+                session.getId(),
+                session.getMaxInactiveInterval(),
+                new Date(session.getCreationTime()),
+                new Date(session.getLastAccessedTime()),
+                session.isNew());
+
+        return "세션 정보가 서버 로그에 출력되었습니다.";
+    }
+
+}

--- a/src/main/java/com/book/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/book/backend/domain/auth/service/AuthService.java
@@ -9,12 +9,15 @@ import com.book.backend.domain.user.mapper.UserMapper;
 import com.book.backend.domain.user.repository.UserRepository;
 import com.book.backend.exception.CustomException;
 import com.book.backend.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,7 +49,7 @@ public class AuthService {
         return userMapper.convertToUserDto(savedUser);
     }
 
-    public UserDto login(LoginDto loginDto) {
+    public UserDto login(HttpServletRequest request, LoginDto loginDto) {
         try {
             // 사용자 인증 시도
             Authentication authentication = authenticationManager.authenticate(
@@ -54,6 +57,10 @@ public class AuthService {
 
             // 인증 성공 시 SecurityContextHolder에 인증 정보 저장
             SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            // 세션에 SecurityContext 저장
+            HttpSession session = request.getSession(true);
+            session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, SecurityContextHolder.getContext());
 
             User user = userRepository.findByLoginId(loginDto.getLoginId())
                     .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/book/backend/global/log/RequestLogger.java
+++ b/src/main/java/com/book/backend/global/log/RequestLogger.java
@@ -17,8 +17,8 @@ public class RequestLogger {
         sb.append("RequestParam : {");
         for(String key : keys){
             if(paramIter.hasNext()){
-                String valueType = paramIter.next().getClass().getSimpleName();
-                sb.append(key).append(": ").append(valueType);
+                String value = paramIter.next().toString();
+                sb.append(key).append(": ").append(value);
                 if(paramIter.hasNext()) sb.append(", ");
             }
         }

--- a/src/main/java/com/book/backend/global/log/RequestLogger.java
+++ b/src/main/java/com/book/backend/global/log/RequestLogger.java
@@ -17,8 +17,8 @@ public class RequestLogger {
         sb.append("RequestParam : {");
         for(String key : keys){
             if(paramIter.hasNext()){
-                String value = paramIter.next().toString();
-                sb.append(key).append(": ").append(value);
+                String valueType = paramIter.next().getClass().getSimpleName();
+                sb.append(key).append(": ").append(valueType);
                 if(paramIter.hasNext()) sb.append(", ");
             }
         }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- [x] #24


## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- [x] 세션 확인용 세션 정보 출력 API 작성
- [x] RequestLogger 수정
- [x] Postman 테스트

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/af69ceeb-3948-4745-8998-1b91444837d5">
AuthService 클래스의 로그인 로직에서, 세션에 SecurityContext를 저장하는 부분이 누락된 것을 확인하여 해당 로직을 추가했습니다.

이후 Postman에서 회원 관리에 해당하는 4개의 API들이 JSESSIONID를 기반으로 정상적으로 동작하는 것을 확인했습니다.


<img width="793" alt="image" src="https://github.com/user-attachments/assets/1563a4bd-360b-4dcb-9a19-cbc508bdbbfd">
추가로, RequestLogger에서 paramIter의 value를 출력할 때 데이터가 아닌 클래스(타입명)를 출력하도록 되어 있어서, 데이터를 출력하는 방식으로 수정했습니다.
