### PR TITLE
[refactor] 장르 컨트롤러에 pageNo, pageSize 파라미터 추가

### DIFF
--- a/src/main/java/com/book/backend/domain/genre/controller/GenreController.java
+++ b/src/main/java/com/book/backend/domain/genre/controller/GenreController.java
@@ -32,17 +32,23 @@ public class GenreController {
     @Operation(summary = "일주일 인기순", description = "장르 코드(2자리)를 입력받아 1주일 인기순 도서 리스트를 반환합니다.",
             parameters = {
                     @Parameter(name = "genreCode", description = "세부 장르 코드 (필수, figma 참고)"),
-                    @Parameter(name = "maxSize", description = "리스트 길이 제한 (선택)")},
+                    @Parameter(name = "pageNo", description = "페이지 번호 (필수)"),
+                    @Parameter(name = "pageSize", description = "페이지 당 요소 수 (필수)")},
             responses = {@ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LoanItemSrchResponseDto.class)),
                     description = LoanItemSrchResponseDto.description)})
     @GetMapping("/aWeekTrend")
     public ResponseEntity<?> aWeekTrend(@RequestParam String genreCode,
-                                        @RequestParam(required = false) Integer maxSize) throws Exception {
+                                        @RequestParam String pageNo,
+                                        @RequestParam String pageSize) throws Exception {
         RequestLogger.param(new String[]{"kdcNum"}, genreCode);
         requestValidate.isValidGenreCode(genreCode);
 
-        LoanItemSrchRequestDto requestDto = LoanItemSrchRequestDto.builder().dtl_kdc(genreCode).build();
-        LinkedList<LoanItemSrchResponseDto> response = genreService.periodToNowTrend(requestDto, 7, maxSize);
+        LoanItemSrchRequestDto requestDto = LoanItemSrchRequestDto.builder()
+                .dtl_kdc(genreCode)
+                .pageNo(pageNo)
+                .pageSize(pageSize)
+                .build();
+        LinkedList<LoanItemSrchResponseDto> response = genreService.periodToNowTrend(requestDto, 7);
 
         return responseTemplate.success(response, HttpStatus.OK);
     }
@@ -51,17 +57,23 @@ public class GenreController {
     @Operation(summary = "한 달 인기순", description = "장르 코드(2자리)를 입력받아 한 달 인기순 도서 리스트를 반환합니다.",
             parameters = {
                     @Parameter(name = "genreCode", description = "세부 장르 코드 (필수, figma 참고)"),
-                    @Parameter(name = "maxSize", description = "리스트 길이 제한 (선택)")},
+                    @Parameter(name = "pageNo", description = "페이지 번호 (필수)"),
+                    @Parameter(name = "pageSize", description = "페이지 당 요소 수 (필수)")},
             responses = {@ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LoanItemSrchResponseDto.class)),
                     description = LoanItemSrchResponseDto.description)})
     @GetMapping("/aMonthTrend")
     public ResponseEntity<?> aMonthTrend(@RequestParam String genreCode,
-                                         @RequestParam(required = false) Integer maxSize) throws Exception {
+                                         @RequestParam String pageNo,
+                                         @RequestParam String pageSize) throws Exception {
         RequestLogger.param(new String[]{"kdcNum"}, genreCode);
         requestValidate.isValidGenreCode(genreCode);
 
-        LoanItemSrchRequestDto requestDto = LoanItemSrchRequestDto.builder().dtl_kdc(genreCode).build();
-        LinkedList<LoanItemSrchResponseDto> response = genreService.periodToNowTrend(requestDto, 30, maxSize);
+        LoanItemSrchRequestDto requestDto = LoanItemSrchRequestDto.builder()
+                .dtl_kdc(genreCode)
+                .pageNo(pageNo)
+                .pageSize(pageSize)
+                .build();
+        LinkedList<LoanItemSrchResponseDto> response = genreService.periodToNowTrend(requestDto, 30);
 
         return responseTemplate.success(response, HttpStatus.OK);
     }
@@ -71,17 +83,23 @@ public class GenreController {
             "단, 월요일 또는 화요일이면 저번 주차로, 아니면 이번 주차로 계산됩니다.",
             parameters = {
                     @Parameter(name = "genreCode", description = "세부 장르 코드 (필수, figma 참고)"),
-                    @Parameter(name = "maxSize", description = "리스트 길이 제한 (선택)")},
+                    @Parameter(name = "pageNo", description = "페이지 번호 (필수)"),
+                    @Parameter(name = "pageSize", description = "페이지 당 요소 수 (필수)")},
             responses = {@ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LoanItemSrchResponseDto.class)),
                     description = LoanItemSrchResponseDto.description)})
     @GetMapping("/thisWeekTrend")
     public ResponseEntity<?> thisWeekTrend(@RequestParam String genreCode,
-                                           @RequestParam(required = false) Integer maxSize) throws Exception {
+                                           @RequestParam String pageNo,
+                                           @RequestParam String pageSize) throws Exception {
         RequestLogger.param(new String[]{"kdcNum"}, genreCode);
         requestValidate.isValidGenreCode(genreCode);
 
-        LoanItemSrchRequestDto requestDto = LoanItemSrchRequestDto.builder().dtl_kdc(genreCode).build();
-        LinkedList<LoanItemSrchResponseDto> response = genreService.thisWeekTrend(requestDto, maxSize);
+        LoanItemSrchRequestDto requestDto = LoanItemSrchRequestDto.builder()
+                .dtl_kdc(genreCode)
+                .pageNo(pageNo)
+                .pageSize(pageSize)
+                .build();
+        LinkedList<LoanItemSrchResponseDto> response = genreService.thisWeekTrend(requestDto);
 
         return responseTemplate.success(response, HttpStatus.OK);
     }
@@ -100,29 +118,35 @@ public class GenreController {
         RequestLogger.param(new String[]{"kdcNum"}, genreCode);
         requestValidate.isValidGenreCode(genreCode);
 
-        LoanItemSrchRequestDto requestDto = LoanItemSrchRequestDto.builder().dtl_kdc(genreCode).build();
+        LoanItemSrchRequestDto requestDto = LoanItemSrchRequestDto.builder()
+                .dtl_kdc(genreCode)
+                .build();
         LinkedList<LoanItemSrchResponseDto> response = genreService.random(requestDto, maxSize);
 
         return responseTemplate.success(response, HttpStatus.OK);
     }
 
-    /**
-     * 신작 인기순 - 중주제 KDC 번호(2자리) 입력 시 2년 내 출판된 인기 도서 목록 리턴
-     */
+    // 신작 인기순
     @Operation(summary = "신작 인기순", description = "장르 코드(2자리)를 입력받아 최근 2년 내 출판된 인기 도서 리스트를 반환합니다.",
             parameters = {
                     @Parameter(name = "genreCode", description = "세부 장르 코드 (필수, figma 참고)"),
-                    @Parameter(name = "maxSize", description = "리스트 길이 제한 (선택)")},
+                    @Parameter(name = "pageNo", description = "페이지 번호 (필수)"),
+                    @Parameter(name = "pageSize", description = "페이지 당 요소 수 (필수)")},
             responses = {@ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = LoanItemSrchResponseDto.class)),
                     description = LoanItemSrchResponseDto.description)})
     @GetMapping("/newTrend")
     public ResponseEntity<?> newTrend(@RequestParam String genreCode,
-                                      @RequestParam(required = false) Integer maxSize) throws Exception {
+                                      @RequestParam String pageNo,
+                                      @RequestParam String pageSize) throws Exception {
         RequestLogger.param(new String[]{"kdcNum"}, genreCode);
         requestValidate.isValidGenreCode(genreCode);
 
-        LoanItemSrchRequestDto requestDto = LoanItemSrchRequestDto.builder().dtl_kdc(genreCode).build();
-        LinkedList<LoanItemSrchResponseDto> response = genreService.newTrend(requestDto, maxSize);
+        LoanItemSrchRequestDto requestDto = LoanItemSrchRequestDto.builder()
+                .dtl_kdc(genreCode)
+                .pageNo(pageNo)
+                .pageSize(pageSize)
+                .build();
+        LinkedList<LoanItemSrchResponseDto> response = genreService.newTrend(requestDto);
 
         return responseTemplate.success(response, HttpStatus.OK);
     }

--- a/src/main/java/com/book/backend/domain/genre/service/GenreResponseParser.java
+++ b/src/main/java/com/book/backend/domain/genre/service/GenreResponseParser.java
@@ -13,22 +13,22 @@ import java.util.LinkedList;
 @RequiredArgsConstructor
 public class GenreResponseParser {
     private final ResponseParser responseParser;
-    private static final int NEW_TREND_YEAR_OFFSET = 2; // 최근 트렌드로 간주되는 연도 범위
+    private static final int NEW_TREND_YEAR_OFFSET = 2;  // 최근 트렌드 연도 범위
 
-    public LinkedList<LoanItemSrchResponseDto> periodTrend(JSONObject jsonResponse, Integer maxSize) {
-        return filterResponses(jsonResponse, maxSize, null);
+    public LinkedList<LoanItemSrchResponseDto> periodTrend(JSONObject jsonResponse) {
+        return filterResponses(jsonResponse, null, null);
     }
 
     public LinkedList<LoanItemSrchResponseDto> random(JSONObject jsonResponse, Integer maxSize) {
-        LinkedList<LoanItemSrchResponseDto> filteredResponses = filterResponses(jsonResponse, maxSize, null);
+        LinkedList<LoanItemSrchResponseDto> filteredResponses = filterResponses(jsonResponse, null, maxSize);
         return RandomPicker.randomPick(filteredResponses, maxSize);
     }
 
-    public LinkedList<LoanItemSrchResponseDto> newTrend(JSONObject jsonResponse, int currentYear, Integer maxSize) {
-        return filterResponses(jsonResponse, maxSize, currentYear);
+    public LinkedList<LoanItemSrchResponseDto> newTrend(JSONObject jsonResponse, int currentYear) {
+        return filterResponses(jsonResponse, currentYear, null);
     }
 
-    private LinkedList<LoanItemSrchResponseDto> filterResponses(JSONObject jsonResponse, Integer maxSize, Integer yearThreshold) {
+    private LinkedList<LoanItemSrchResponseDto> filterResponses(JSONObject jsonResponse, Integer yearThreshold, Integer maxSize) {
         LinkedList<LoanItemSrchResponseDto> loanTrendResponseList = responseParser.loanTrend(jsonResponse);
         LinkedList<LoanItemSrchResponseDto> responseList = new LinkedList<>();
 

--- a/src/main/java/com/book/backend/domain/genre/service/GenreService.java
+++ b/src/main/java/com/book/backend/domain/genre/service/GenreService.java
@@ -41,15 +41,15 @@ public class GenreService {
                 .orElseThrow(() -> new IllegalArgumentException("KDC 번호가" + mainKdcNum + subKdcNum + "인 장르를 찾을 수 없습니다."));
     }
 
-    public LinkedList<LoanItemSrchResponseDto> periodToNowTrend(LoanItemSrchRequestDto requestDto, Integer dayPeriod, Integer maxSize) throws Exception {
+    public LinkedList<LoanItemSrchResponseDto> periodToNowTrend(LoanItemSrchRequestDto requestDto, Integer dayPeriod) throws Exception {
         LocalDate today = LocalDate.now();
         LocalDate startDt = today.minusDays(dayPeriod + 1);
         LocalDate endDt = today.minusDays(1);
 
-        return periodTrend(requestDto, startDt, endDt, maxSize);
+        return periodTrend(requestDto, startDt, endDt);
     }
 
-    public LinkedList<LoanItemSrchResponseDto> thisWeekTrend(LoanItemSrchRequestDto requestDto, Integer maxSize) throws Exception {
+    public LinkedList<LoanItemSrchResponseDto> thisWeekTrend(LoanItemSrchRequestDto requestDto) throws Exception {
         LocalDate today = LocalDate.now();
         LocalDate startDt, endDt;
         // 월요일 또는 화요일이면 저번주로, 아니면 이번주로 계산
@@ -61,18 +61,18 @@ public class GenreService {
             endDt = today.minusDays(1);
         }
 
-        return periodTrend(requestDto, startDt, endDt, maxSize);
+        return periodTrend(requestDto, startDt, endDt);
     }
 
     // periodToNowTrend, thisWeekTrend에 의해 호출됨
-    public LinkedList<LoanItemSrchResponseDto> periodTrend(LoanItemSrchRequestDto requestDto, LocalDate startDt, LocalDate endDt, Integer maxSize) throws Exception {
+    public LinkedList<LoanItemSrchResponseDto> periodTrend(LoanItemSrchRequestDto requestDto, LocalDate startDt, LocalDate endDt) throws Exception {
         String subUrl = "loanItemSrch";
 
         requestDto.setStartDt(startDt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
         requestDto.setEndDt(endDt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
 
         JSONObject JsonResponse = openAPI.connect(subUrl, requestDto, new LoanItemSrchResponseDto());
-        return new LinkedList<>(genreResponseParser.periodTrend(JsonResponse, maxSize));
+        return new LinkedList<>(genreResponseParser.periodTrend(JsonResponse));
     }
 
     public LinkedList<LoanItemSrchResponseDto> random(LoanItemSrchRequestDto requestDto, Integer maxSize) throws Exception {
@@ -85,7 +85,7 @@ public class GenreService {
         return new LinkedList<>(genreResponseParser.random(JsonResponse, maxSize));
     }
 
-    public LinkedList<LoanItemSrchResponseDto> newTrend(LoanItemSrchRequestDto requestDto, Integer maxSize) throws Exception {
+    public LinkedList<LoanItemSrchResponseDto> newTrend(LoanItemSrchRequestDto requestDto) throws Exception {
         String subUrl = "loanItemSrch";
 
         requestDto.setPageSize("1500");  // 연도로 필터링하기 전 페이지 크기 설정
@@ -94,7 +94,7 @@ public class GenreService {
 
         JSONObject JsonResponse = openAPI.connect(subUrl, requestDto, new LoanItemSrchResponseDto());
 
-        return new LinkedList<>(genreResponseParser.newTrend(JsonResponse, currentYear, maxSize));
+        return new LinkedList<>(genreResponseParser.newTrend(JsonResponse, currentYear));
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- [x] #47 


## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- [x] 장르 컨트롤러에 pageNo, pageSize 파라미터 추가


### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 페이지네이션을 반영하여 장르 컨트롤러에 pageNo, pageSize 파라미터를 추가하고 그에 따른 로직을 수정했습니다!
> 단, random api에 경우 페이지네이션을 적용하지 않았습니다.
>   - 이유는 로직상에서 자체적으로 리스트를 셔플하기 때문에, open api에서 제공하는 페이지네이션을 사용한다면 중복 없이 랜덤 결과를 생성할 수 없기 때문입니다. (즉 api를 호출할 때마다 중복된 책이 보여질 여지가 있습니다.) 
>   - 이 부분과 관련해서, random api에 한해서는 캐싱 기반으로 보여지게끔 할 수 있는지 프론트엔드분들께 여쭤볼 예정인데, 괜찮을지 의견 주시면 감사드리겠습니다!
