### PR TITLE
#60 custom page filter

### DIFF
--- a/src/main/java/com/book/backend/domain/genre/controller/GenreController.java
+++ b/src/main/java/com/book/backend/domain/genre/controller/GenreController.java
@@ -143,10 +143,8 @@ public class GenreController {
 
         LoanItemSrchRequestDto requestDto = LoanItemSrchRequestDto.builder()
                 .dtl_kdc(genreCode)
-                .pageNo(pageNo)
-                .pageSize(pageSize)
                 .build();
-        LinkedList<LoanItemSrchResponseDto> response = genreService.newTrend(requestDto);
+        LinkedList<LoanItemSrchResponseDto> response = genreService.newTrend(requestDto, pageNo, pageSize);
 
         return responseTemplate.success(response, HttpStatus.OK);
     }

--- a/src/main/java/com/book/backend/domain/genre/service/GenreResponseParser.java
+++ b/src/main/java/com/book/backend/domain/genre/service/GenreResponseParser.java
@@ -30,10 +30,12 @@ public class GenreResponseParser {
         return RandomPicker.randomPick(filteredResponses, maxSize);
     }
 
-    public LinkedList<LoanItemSrchResponseDto> newTrend(JSONObject jsonResponse, int currentYear) {
+    public LinkedList<LoanItemSrchResponseDto> newTrend(JSONObject jsonResponse, int currentYear,
+                                                        String filteredPageNo, String filteredPageSize) {
         log.trace("GenreResponseParser > newTrend()");
 
-        return filterResponses(jsonResponse, currentYear, null);
+        LinkedList<LoanItemSrchResponseDto> filteredResponse = filterResponses(jsonResponse, currentYear, null);
+        return responseParser.customPageFilter(filteredResponse, filteredPageNo, filteredPageSize);
     }
 
     private LinkedList<LoanItemSrchResponseDto> filterResponses(JSONObject jsonResponse, Integer yearThreshold, Integer maxSize) {
@@ -64,4 +66,5 @@ public class GenreResponseParser {
         }
         return responseList;
     }
+
 }

--- a/src/main/java/com/book/backend/domain/genre/service/GenreService.java
+++ b/src/main/java/com/book/backend/domain/genre/service/GenreService.java
@@ -85,7 +85,8 @@ public class GenreService {
         return new LinkedList<>(genreResponseParser.random(JsonResponse, maxSize));
     }
 
-    public LinkedList<LoanItemSrchResponseDto> newTrend(LoanItemSrchRequestDto requestDto) throws Exception {
+    public LinkedList<LoanItemSrchResponseDto> newTrend(LoanItemSrchRequestDto requestDto,
+                                                        String filteredPageNo, String filteredPageSize) throws Exception {
         String subUrl = "loanItemSrch";
 
         requestDto.setPageSize("1500");  // 연도로 필터링하기 전 페이지 크기 설정
@@ -94,7 +95,7 @@ public class GenreService {
 
         JSONObject JsonResponse = openAPI.connect(subUrl, requestDto, new LoanItemSrchResponseDto());
 
-        return new LinkedList<>(genreResponseParser.newTrend(JsonResponse, currentYear));
+        return new LinkedList<>(genreResponseParser.newTrend(JsonResponse, currentYear, filteredPageNo, filteredPageSize));
     }
 
 }

--- a/src/main/java/com/book/backend/domain/openapi/service/ResponseParser.java
+++ b/src/main/java/com/book/backend/domain/openapi/service/ResponseParser.java
@@ -4,12 +4,8 @@ import com.book.backend.domain.detail.dto.BookInfoDto;
 import com.book.backend.domain.detail.dto.CoLoanBooksDto;
 import com.book.backend.domain.detail.dto.Top3LoanUserDto;
 import com.book.backend.domain.detail.dto.RecommendDto;
-import com.book.backend.domain.openapi.dto.response.DetailResponseDto;
-import com.book.backend.domain.openapi.dto.response.HotTrendResponseDto;
-import com.book.backend.domain.openapi.dto.response.LoanItemSrchResponseDto;
-import com.book.backend.domain.openapi.dto.response.MonthlyKeywordsResponseDto;
-import com.book.backend.domain.openapi.dto.response.RecommendListResponseDto;
-import com.book.backend.domain.openapi.dto.response.SearchResponseDto;
+import com.book.backend.domain.openapi.dto.response.*;
+
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -326,5 +322,22 @@ public class ResponseParser {
                 .coLoanBooksDtoList(coLoanBooksList)
                 .recommendResponseDtoList(recommendBooksList)
                 .build();
+    }
+
+    public <T extends OpenAPIResponseInterface> LinkedList<T> customPageFilter(LinkedList<T> responseList, String filteredPageNo, String filteredPageSize) {
+        log.trace("ResponseParser > customPageFilter()");
+
+        int pageNo = Integer.parseInt(filteredPageNo);
+        int pageSize = Integer.parseInt(filteredPageSize);
+
+        int startIdx = (pageNo - 1) * pageSize;
+        int endIdx = Math.min(startIdx + pageSize, responseList.size());
+
+        try {
+            return new LinkedList<>(responseList.subList(startIdx, endIdx));
+        } catch (IllegalArgumentException e) {
+            return new LinkedList<>();
+        }
+
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- [x] #60 


## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- [x] customPageFilter 추가
- [x] GenreController 신작 인기순 API에 customPageFilter 반영


### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ResponseParser에 커스텀 페이지네이션을 수행하는 customPageFilter를 작성했으며, 재사용 가능합니다!
